### PR TITLE
chore: update wordpress compatibility version

### DIFF
--- a/svn/click-to-tweet-by-todaymade/trunk/assets/css/styles.css
+++ b/svn/click-to-tweet-by-todaymade/trunk/assets/css/styles.css
@@ -1,6 +1,7 @@
 .tm-tweet-clear {
   zoom: 1;
 }
+
 .tm-tweet-clear:after {
   display: block;
   visibility: hidden;
@@ -8,6 +9,7 @@
   clear: both;
   content: ".";
 }
+
 .tm-click-to-tweet {
   display: block;
   background-color: #fff;
@@ -21,9 +23,11 @@
   margin: 15px 0px;
   zoom: 1;
 }
+
 .tm-click-to-tweet .clearfix {
   zoom: 1;
 }
+
 .tm-click-to-tweet .clearfix:after {
   display: block;
   visibility: hidden;
@@ -31,32 +35,39 @@
   clear: both;
   content: ".";
 }
+
 .tm-click-to-tweet .clear {
   clear: both;
 }
+
 .tm-click-to-tweet .f-left {
   float: left;
   display: inline-block;
   position: relative;
 }
+
 .tm-click-to-tweet .f-right {
   float: right;
   display: inline-block;
   position: relative;
 }
+
 .tm-click-to-tweet .list-reset {
   list-style: none;
   margin: 0;
   padding: 0;
 }
+
 .tm-click-to-tweet .list-reset li {
   list-style: none;
   margin: 0;
   padding: 0;
 }
+
 .tm-click-to-tweet .list-float {
   zoom: 1;
 }
+
 .tm-click-to-tweet .list-float:after {
   display: block;
   visibility: hidden;
@@ -64,27 +75,32 @@
   clear: both;
   content: ".";
 }
+
 .tm-click-to-tweet .list-float li {
   float: left;
   display: inline-block;
 }
+
 .tm-click-to-tweet .kill-box-shadow {
   box-shadow: none;
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
 }
+
 .tm-click-to-tweet .alignright {
   float: right;
   margin-bottom: 10px;
   margin-left: 10px;
   text-align: right;
 }
+
 .tm-click-to-tweet .alignleft {
   float: left;
   margin-bottom: 10px;
   margin-right: 10px;
   text-align: right;
 }
+
 .tm-click-to-tweet:after {
   content: ".";
   display: block;
@@ -93,11 +109,13 @@
   line-height: 0;
   height: 0;
 }
+
 .tm-click-to-tweet .tm-ctt-reset {
   margin: 0;
   padding: 0;
   position: relative;
 }
+
 .tm-click-to-tweet:after {
   display: block;
   visibility: hidden;
@@ -105,13 +123,16 @@
   clear: both;
   content: ".";
 }
+
 .tm-click-to-tweet a {
   text-decoration: none;
   text-transform: none;
 }
+
 .tm-click-to-tweet a:hover {
   text-decoration: none;
 }
+
 .tm-click-to-tweet .tm-ctt-text {
   margin: 0;
   padding: 0;
@@ -119,6 +140,7 @@
   margin-bottom: 10px;
   word-wrap: break-word;
 }
+
 .tm-click-to-tweet .tm-ctt-text a {
   margin: 0;
   padding: 0;
@@ -132,10 +154,12 @@
   text-decoration: none;
   text-transform: none;
 }
+
 .tm-click-to-tweet .tm-ctt-text a:hover {
   text-decoration: none;
   color: #666666;
 }
+
 .tm-click-to-tweet a.tm-ctt-btn {
   margin: 0;
   padding: 0;
@@ -152,19 +176,23 @@
   text-decoration: none;
   background: transparent url(../img/twitter-little-bird.png) no-repeat right top;
 }
+
 .tm-click-to-tweet a.tm-ctt-btn:hover {
   text-decoration: none;
   color: #666666;
   text-transform: uppercase;
 }
+
 .tm-click-to-tweet .tm-powered-by {
   font-size: 10px;
   color: #999999;
 }
+
 .tm-click-to-tweet .tm-powered-by a {
   font-size: 10px;
   color: #999999 !important;
 }
+
 .tm-click-to-tweet .tm-powered-by a:hover {
   color: #999999 !important;
   text-decoration: underline !important;

--- a/svn/click-to-tweet-by-todaymade/trunk/assets/js/tmclicktotweet_plugin.js
+++ b/svn/click-to-tweet-by-todaymade/trunk/assets/js/tmclicktotweet_plugin.js
@@ -1,27 +1,31 @@
-(function() {
-    tinymce.create('tinymce.plugins.TMClickToTweet', {
-        init: function(ed, url) {
-            ed.addButton('tmclicktotweet', {
-                title: 'tmclicktotweet.quickaddd',
-                image: url.replace("/js", "") + '/img/twitter-little-bird-button.png',
-                onclick: function() {
-                    var m = prompt("Click To Tweet", "Enter your tweets");
-                    if (m != null && m != 'undefined' && m != 'Enter your tweets' && m != '') ed.execCommand('mceInsertContent', false, '[Tweet "' + m + '"]');
-                }
-            });
+(function () {
+  tinymce.create('tinymce.plugins.TMClickToTweet', {
+    init: function (ed, url) {
+      ed.addButton('tmclicktotweet', {
+        title: 'tmclicktotweet.quickaddd',
+        image: url.replace('/js', '') + '/img/twitter-little-bird-button.png',
+        onclick: function () {
+          var m = prompt('Click To Tweet', 'Enter your tweets');
+          if (m !== null && m !== 'undefined' && m !== 'Enter your tweets' && m !== '') {
+            ed.execCommand('mceInsertContent', false, `[Tweet "${m}"]`);
+          }
         },
-        createControl: function(n, cm) {
-            return null;
-        },
-        getInfo: function() {
-            return {
-                longname: "Click To Tweet",
-                author: 'Todaymade',
-                authorurl: 'http://coschedule.com/',
-                infourl: 'http://coschedule.com/click-to-tweet',
-                version: "1.0"
-            };
-        }
-    });
-    tinymce.PluginManager.add('tmclicktotweet', tinymce.plugins.TMClickToTweet);
+      });
+    },
+
+    createControl: function (n, cm) {
+      return null;
+    },
+
+    getInfo: function () {
+      return {
+        longname: 'Click To Tweet',
+        author: 'CoSchedule',
+        authorurl: 'http://coschedule.com/',
+        infourl: 'http://coschedule.com/click-to-tweet',
+        version: '1.0',
+      };
+    },
+  });
+  tinymce.PluginManager.add('tmclicktotweet', tinymce.plugins.TMClickToTweet);
 })();

--- a/svn/click-to-tweet-by-todaymade/trunk/readme.txt
+++ b/svn/click-to-tweet-by-todaymade/trunk/readme.txt
@@ -3,8 +3,8 @@ Contributors: CoSchedule
 Donate link: https://coschedule.com/click-to-tweet
 Tags: click to tweet, twitter, tweet, twitter plugin, Twitter boxes, share, social media, auto post
 Requires at least: 3.1
-Tested up to: 4.9.8
-Stable tag: 1.4
+Tested up to: 6.8
+Stable tag: 1.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -49,6 +49,8 @@ Find out more here: [http://coschedule.com/click-to-tweet](http://coschedule.com
 4. Click To Tweet box on a sample blog.
 
 == Changelog ==
+= 1.5 =
+* Update WordPress compatibility version
 
 = 1.4 =
 * Improved support for twitter 280 character length
@@ -66,6 +68,8 @@ Find out more here: [http://coschedule.com/click-to-tweet](http://coschedule.com
 * Initial Release
 
 == Upgrade Notice ==
+= 1.5 =
+* Update WordPress compatibility version
 
 = 1.4 =
 * This update fixes the max length tweet to 280 characters

--- a/svn/click-to-tweet-by-todaymade/trunk/tm-click-to-tweet.php
+++ b/svn/click-to-tweet-by-todaymade/trunk/tm-click-to-tweet.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Click To Tweet
 Description: Add click to tweet boxes to your WordPress posts, easily.
-Version: 1.4
+Version: 1.5
 Author: CoSchedule
 Author URI: https://coschedule.com/
 Plugin URI: https://coschedule.com/click-to-tweet
@@ -10,275 +10,285 @@ Plugin URI: https://coschedule.com/click-to-tweet
 
 // Check for existing class
 if ( ! class_exists( 'tm_clicktotweet' ) ) {
-/**
-	 * Main Class
-	 */
-	class tm_clicktotweet  {
+    /**
+     * Main Class
+     */
+    class tm_clicktotweet {
 
-		/**
-		 * Class constructor: initializes class variables and adds actions and filters.
-		 */
-		public function __construct() {
-			$this->tm_clicktotweet();
-		}
+        /**
+         * Class constructor: initializes class variables and adds actions and filters.
+         */
+        public function __construct() {
+            $this->tm_clicktotweet();
+        }
 
-		public function tm_clicktotweet() {
-			register_activation_hook( __FILE__, array( __CLASS__, 'activation' ) );
-			register_deactivation_hook( __FILE__, array( __CLASS__, 'deactivation' ) );
+        public function tm_clicktotweet() {
+            register_activation_hook( __FILE__, array( __CLASS__, 'activation' ) );
+            register_deactivation_hook( __FILE__, array( __CLASS__, 'deactivation' ) );
 
-			// Register global hooks
-			$this->register_global_hooks();
+            // Register global hooks
+            $this->register_global_hooks();
 
-			// Register admin only hooks
-			if(is_admin()) {
-				$this->register_admin_hooks();
-			}
-		}
-
-		/**
-		 * Print the contents of an array
-		 */
-		public function debug($array) {
-			echo '<pre>';
-			print_r($array);
-			echo '</pre>';
-		}
-
-		/**
-		 * Handles activation tasks, such as registering the uninstall hook.
-		 */
-		public function activation() {
-			register_uninstall_hook( __FILE__, array( __CLASS__, 'uninstall' ) );
-		}
-
-		/**
-		 * Handles deactivation tasks, such as deleting plugin options.
-		 */
-		public function deactivation() {
-
-		}
-
-		/**
-		 * Handles uninstallation tasks, such as deleting plugin options.
-		 */
-		public function uninstall() {
-			delete_option('twitter-handle');
-		}
-
-		/**
-		 * Registers global hooks, these are added to both the admin and front-end.
-		 */
-		public function register_global_hooks() {
-			add_action('wp_enqueue_scripts', array($this, 'add_css'));
-			add_filter('the_content', array($this, 'replace_tags'), 1);
-		}
-
-		/**
-		 * Registers admin only hooks.
-		 */
-		public function register_admin_hooks() {
-			// Cache bust tinymce
-			add_filter('tiny_mce_version', array($this, 'refresh_mce'));
-
-			// Add Settings Link
-			add_action('admin_menu', array($this, 'admin_menu'));
-
-			// Add settings link to plugins listing page
-			add_filter('plugin_action_links', array($this, 'plugin_settings_link'), 2, 2);
-
-			// Add button plugin to TinyMCE
-			add_action('init', array($this, 'tinymce_button'));
-		}
-
-		public function tinymce_button() {
-			if (!current_user_can('edit_posts') && !current_user_can('edit_pages')) {
-				return;
-			}
-
-			if (get_user_option('rich_editing') == 'true') {
-				add_filter('mce_external_plugins', array($this, 'tinymce_register_plugin'));
-				add_filter('mce_buttons', array($this, 'tinymce_register_button'));
-			}
-		}
-
-		public function tinymce_register_button($buttons) {
-		   array_push($buttons, "|", "tmclicktotweet");
-		   return $buttons;
-		}
-
-		public function tinymce_register_plugin($plugin_array) {
-		   $plugin_array['tmclicktotweet'] = plugins_url( '/assets/js/tmclicktotweet_plugin.js', __FILE__);
-		   return $plugin_array;
-		}
-
-		/**
-		 * Admin: Add settings link to plugin management page
-		 */
-		public function plugin_settings_link($actions, $file) {
-			if(false !== strpos($file, 'tm-click-to-tweet')) {
-				$actions['settings'] = '<a href="options-general.php?page=tmclicktotweet">Settings</a>';
-			}
-			return $actions;
-		}
-
-		/**
-		 * Admin: Add Link to sidebar admin menu
-		 */
-		public function admin_menu() {
-			add_action('admin_init', array($this, 'register_settings'));
-			add_options_page('Click To Tweet Options', 'Click To Tweet', 'manage_options', 'tmclicktotweet', array($this, 'settings_page'));
-		}
-
-		/**
-		 * Admin: Settings page
-		 */
-		public function settings_page() {
-			if ( !current_user_can( 'manage_options' ) )  {
-				wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
-			} ?>
-
-			<div class="wrap">
-
-				<?php screen_icon(); ?>
-				<h2>Click To Tweet</h2>
-
-				<hr/>
-
-				<div style="float:right; margin-left:20px;">
-					<a href="http://coschedule.com/?utm_source=WordPress+Plugin&utm_medium=banner&utm_campaign=WordPress+Plugin" target="_blank">
-						<img src="http://space.todaymade.com/wp-plugins/click-to-tweet-sidebar/coschedule-Sidebar.png" alt="The Better Editorial Calendar For WordPress" />
-					</a>
-				</div>
-
-				<h2>Instructions</h2>
-				<p>
-					To use, simply include the Click to Tweet code in your post. Place your message within the parentheses. Tweet length will be automatically truncated to 120 characters.  <pre>[Tweet "This is a tweet. It is only a tweet."]</pre>
-				</p>
-
-				<h2>Settings</h2>
-
-				<p>Enter your Twitter handle to add "via @yourhandle" to your tweets. Do not include the @ symbol.</p>
-				<form method="post" action="options.php" style="display: inline-block;">
-					<?php settings_fields( 'tmclicktotweet-options' ); ?>
-
-					<table class="form-table">
-		        		<tr valign="top">
-		        			<th style="width: 200px;"><label>Your Twitter Handle</label></th>
-							<td><input type="text" name="twitter-handle" value="<?php echo get_option('twitter-handle'); ?>" /></td>
-						</tr>
-						<tr>
-							<td></td>
-							<td><?php submit_button(); ?></td>
-					</table>
-			 	</form>
-
-			 	<hr/>
-			 	<em>A plugin by <a href="http://coschedule.com" target="_blank">CoSchedule</a> © 2014</em>
-			</div>
-			<?php
-		}
-
-		/**
-		 * Admin: Whitelist the settings used on the settings page
-		 */
-		public function register_settings() {
-			register_setting('tmclicktotweet-options', 'twitter-handle', array($this, 'validate_settings'));
-		}
-
-		/**
-		 * Admin: Validate settings
-		 */
-		public function validate_settings($input) {
-			return str_replace('@', '', strip_tags(stripslashes($input)));
-		}
-
-		/**
-		 * Add CSS needed for styling the plugin
-		 */
-		public function add_css() {
-		    wp_register_style('tm_clicktotweet', plugins_url('/assets/css/styles.css', __FILE__));
-		    wp_enqueue_style('tm_clicktotweet');
-		}
-
-		/**
-		 * Shorten text length to 257 with via handle text included.
-		 */
-		public function shorten($input, $handle, $ellipses = true, $strip_html = true) {
-
-            $max_tweet_length = 280;
-            $default_url_count = 23;
-            $max_tweet_length_with_url = $max_tweet_length - $default_url_count;
-            $limit = $max_tweet_length_with_url;
-
-            if (!empty($handle)) {
-                $via_handle_length = strlen(" via @".$handle);
-                $limit = $limit - $via_handle_length;
+            // Register admin only hooks
+            if ( is_admin() ) {
+                $this->register_admin_hooks();
             }
-		    if ($strip_html) {
-		        $input = strip_tags($input);
-		    }
-		    if (strlen($input) <= $limit) {
-		        return $input;
-		    }
+        }
+
+        /**
+         * Print the contents of an array
+         */
+        public function debug( $array ) {
+            echo '<pre>';
+            print_r( $array );
+            echo '</pre>';
+        }
+
+        /**
+         * Handles activation tasks, such as registering the uninstall hook.
+         */
+        public static function activation() {
+            register_uninstall_hook( __FILE__, array( __CLASS__, 'uninstall' ) );
+        }
+
+        /**
+         * Handles deactivation tasks, such as deleting plugin options.
+         */
+        public static function deactivation() {
+
+        }
+
+        /**
+         * Handles uninstallation tasks, such as deleting plugin options.
+         */
+        public static function uninstall() {
+            delete_option( 'twitter-handle' );
+        }
+
+        /**
+         * Registers global hooks, these are added to both the admin and front-end.
+         */
+        public function register_global_hooks() {
+            add_action( 'wp_enqueue_scripts', array( $this, 'add_css' ) );
+            add_filter( 'the_content', array( $this, 'replace_tags' ), 1 );
+        }
+
+        /**
+         * Registers admin only hooks.
+         */
+        public function register_admin_hooks() {
+            // Cache bust tinymce
+            add_filter( 'tiny_mce_version', array( $this, 'refresh_mce' ) );
+
+            // Add Settings Link
+            add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+
+            // Add settings link to plugins listing page
+            add_filter( 'plugin_action_links', array( $this, 'plugin_settings_link' ), 2, 2 );
+
+            // Add button plugin to TinyMCE
+            add_action( 'init', array( $this, 'tinymce_button' ) );
+        }
+
+        public function tinymce_button() {
+            if ( ! current_user_can( 'edit_posts' ) && ! current_user_can( 'edit_pages' ) ) {
+                return;
+            }
+
+            if ( get_user_option( 'rich_editing' ) == 'true' ) {
+                add_filter( 'mce_external_plugins', array( $this, 'tinymce_register_plugin' ) );
+                add_filter( 'mce_buttons', array( $this, 'tinymce_register_button' ) );
+            }
+        }
+
+        public function tinymce_register_button( $buttons ) {
+            array_push( $buttons, "|", "tmclicktotweet" );
+
+            return $buttons;
+        }
+
+        public function tinymce_register_plugin( $plugin_array ) {
+            $plugin_array['tmclicktotweet'] = plugins_url( '/assets/js/tmclicktotweet_plugin.js', __FILE__ );
+
+            return $plugin_array;
+        }
+
+        /**
+         * Admin: Add settings link to plugin management page
+         */
+        public function plugin_settings_link( $actions, $file ) {
+            if ( false !== strpos( $file, 'tm-click-to-tweet' ) ) {
+                $actions['settings'] = '<a href="options-general.php?page=tmclicktotweet">Settings</a>';
+            }
+
+            return $actions;
+        }
+
+        /**
+         * Admin: Add Link to sidebar admin menu
+         */
+        public function admin_menu() {
+            add_action( 'admin_init', array( $this, 'register_settings' ) );
+            add_options_page( 'Click To Tweet Options', 'Click To Tweet', 'manage_options', 'tmclicktotweet', array( $this, 'settings_page' ) );
+        }
+
+        /**
+         * Admin: Settings page
+         */
+        public function settings_page() {
+            if ( ! current_user_can( 'manage_options' ) ) {
+                wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
+            } ?>
+
+            <div class="wrap">
+
+                <?php screen_icon(); ?>
+                <h2>Click To Tweet</h2>
+
+                <hr/>
+
+                <h2>Instructions</h2>
+                <p>
+                    To use, simply include the Click to Tweet code in your post. Place your message within the parentheses. Tweet length will be automatically truncated to 120 characters.
+                <pre>[Tweet "This is a tweet. It is only a tweet."]</pre>
+                </p>
+
+                <h2>Settings</h2>
+
+                <p>Enter your Twitter handle to add "via @yourhandle" to your tweets. Do not include the @ symbol.</p>
+                <form method="post" action="options.php" style="display: inline-block;">
+                    <?php settings_fields( 'tmclicktotweet-options' ); ?>
+
+                    <table class="form-table">
+                        <tr valign="top">
+                            <th style="width: 200px;">
+                                <label>Your Twitter Handle</label>
+                            </th>
+                            <td>
+                                <input type="text" name="twitter-handle" value="<?php echo get_option( 'twitter-handle' ); ?>"/>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td><?php submit_button(); ?></td>
+                    </table>
+                </form>
+
+                <hr/>
+                <em>A plugin by
+                    <a href="http://coschedule.com" target="_blank">CoSchedule</a>
+                    © 2025
+                </em>
+            </div>
+            <?php
+        }
+
+        /**
+         * Admin: Whitelist the settings used on the settings page
+         */
+        public function register_settings() {
+            register_setting( 'tmclicktotweet-options', 'twitter-handle', array( $this, 'validate_settings' ) );
+        }
+
+        /**
+         * Admin: Validate settings
+         */
+        public function validate_settings( $input ) {
+            return str_replace( '@', '', strip_tags( stripslashes( $input ) ) );
+        }
+
+        /**
+         * Add CSS needed for styling the plugin
+         */
+        public function add_css() {
+            wp_register_style( 'tm_clicktotweet', plugins_url( '/assets/css/styles.css', __FILE__ ) );
+            wp_enqueue_style( 'tm_clicktotweet' );
+        }
+
+        /**
+         * Shorten text length to 257 with via handle text included.
+         */
+        public function shorten( $input, $handle, $ellipses = true, $strip_html = true ) {
+
+            $max_tweet_length          = 280;
+            $default_url_count         = 23;
+            $max_tweet_length_with_url = $max_tweet_length - $default_url_count;
+            $limit                     = $max_tweet_length_with_url;
+
+            if ( ! empty( $handle ) ) {
+                $via_handle_length = strlen( " via @" . $handle );
+                $limit             = $limit - $via_handle_length;
+            }
+            if ( $strip_html ) {
+                $input = strip_tags( $input );
+            }
+            if ( strlen( $input ) <= $limit ) {
+                return $input;
+            }
             $ellipses = '...';
 
-            $last_space = strrpos(substr($input, 0, $limit - strlen($ellipses)), ' ');
-		    $trimmed_text = substr($input, 0, $last_space);
-		    if ($ellipses) {
-		        $trimmed_text .= $ellipses;
-		    }
-		    return $trimmed_text;
-		}
+            $last_space   = strrpos( substr( $input, 0, $limit - strlen( $ellipses ) ), ' ' );
+            $trimmed_text = substr( $input, 0, $last_space );
+            if ( $ellipses ) {
+                $trimmed_text .= $ellipses;
+            }
 
-		/**
-		 * Replacement of Tweet tags with the correct HTML
-		 */
-		public function tweet($matches) {
-		    $handle = get_option('twitter-handle');
-		    if (!empty($handle)) {
-		        $handle_code = "&via=".$handle."&related=".$handle;
-		    }
-		    $text = $matches[1];
-		    $short = $this->shorten($text, $handle);
-		    return "<div class='tm-tweet-clear'></div><div class='tm-click-to-tweet'><div class='tm-ctt-text'><a href='https://twitter.com/share?text=".urlencode($short).$handle_code."&url=".get_permalink()."' target='_blank'>".$short."</a></div><a href='https://twitter.com/share?text=".urlencode($short)."".$handle_code."&url=".get_permalink()."' target='_blank' class='tm-ctt-btn'>Click To Tweet</a><div class='tm-ctt-tip'></div></div>";
-		}
+            return $trimmed_text;
+        }
 
-		/**
-		 * Replacement of Tweet tags with the correct HTML for a rss feed
-		 */
-		public function tweet_feed($matches) {
-		    $handle = get_option('twitter-handle');
-		    if (!empty($handle)) {
-		        $handle_code = "&via=".$handle."&related=".$handle;
-		    }
-		    $text = $matches[1];
-		    $short = $this->shorten($text, $handle);
-		    return "<hr /><p><em>".$short."</em><br /><a href='https://twitter.com/share?text=".urlencode($short).$handle_code."&url=".get_permalink()."' target='_blank'>Click To Tweet</a></p><hr />";
-		}
+        /**
+         * Replacement of Tweet tags with the correct HTML
+         */
+        public function tweet( $matches ) {
+            $handle = get_option( 'twitter-handle' );
+            if ( ! empty( $handle ) ) {
+                $handle_code = "&via=" . $handle . "&related=" . $handle;
+            }
+            $text  = $matches[1];
+            $short = $this->shorten( $text, $handle );
 
-		/**
-		 * Regular expression to locate tweet tags
-		 */
-		public function replace_tags($content) {
-			if (!is_feed()) {
-				$content = preg_replace_callback("/\[tweet \"(.*?)\"]/i", array($this, 'tweet'), $content);
-			} else {
-				$content = preg_replace_callback("/\[tweet \"(.*?)\"]/i", array($this, 'tweet_feed'), $content);
-			}
-			return $content;
-		}
+            return "<div class='tm-tweet-clear'></div><div class='tm-click-to-tweet'><div class='tm-ctt-text'><a href='https://twitter.com/share?text=" . urlencode( $short ) . $handle_code . "&url=" . get_permalink() . "' target='_blank'>" . $short . "</a></div><a href='https://twitter.com/share?text=" . urlencode( $short ) . "" . $handle_code . "&url=" . get_permalink() . "' target='_blank' class='tm-ctt-btn'>Click To Tweet</a><div class='tm-ctt-tip'></div></div>";
+        }
 
-		/**
-		 * Cache bust tinymce
-		 */
-		public function refresh_mce($ver) {
-			$ver += 3;
-			return $ver;
-		}
-	} // End tm_clicktotweet class
+        /**
+         * Replacement of Tweet tags with the correct HTML for a rss feed
+         */
+        public function tweet_feed( $matches ) {
+            $handle = get_option( 'twitter-handle' );
+            if ( ! empty( $handle ) ) {
+                $handle_code = "&via=" . $handle . "&related=" . $handle;
+            }
+            $text  = $matches[1];
+            $short = $this->shorten( $text, $handle );
 
-	// Init Class
-	new tm_clicktotweet();
+            return "<hr /><p><em>" . $short . "</em><br /><a href='https://twitter.com/share?text=" . urlencode( $short ) . $handle_code . "&url=" . get_permalink() . "' target='_blank'>Click To Tweet</a></p><hr />";
+        }
+
+        /**
+         * Regular expression to locate tweet tags
+         */
+        public function replace_tags( $content ) {
+            if ( ! is_feed() ) {
+                $content = preg_replace_callback( "/\[tweet \"(.*?)\"]/i", array( $this, 'tweet' ), $content );
+            } else {
+                $content = preg_replace_callback( "/\[tweet \"(.*?)\"]/i", array( $this, 'tweet_feed' ), $content );
+            }
+
+            return $content;
+        }
+
+        /**
+         * Cache bust tinymce
+         */
+        public function refresh_mce( $ver ) {
+            $ver += 3;
+
+            return $ver;
+        }
+    } // End tm_clicktotweet class
+
+    // Init Class
+    new tm_clicktotweet();
 }
 
 ?>


### PR DESCRIPTION
Fixes
<img width="631" height="155" alt="image" src="https://github.com/user-attachments/assets/7bce37fa-911c-4b42-a68a-b20cce20a39c" />

Update the plugin to be compatible with the latest WordPress versions
Reformats the code in accordance with [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/)

(Would be easiest to review with [w=1](https://github.com/CoSchedule/click-to-tweet/pull/3/files?w=1) due to the whitespace changes)